### PR TITLE
[LineChart] Added ability to specify x and y keys as functions

### DIFF
--- a/packages/charts/src/Line/Line.tsx
+++ b/packages/charts/src/Line/Line.tsx
@@ -4,8 +4,8 @@ import * as d3 from 'd3';
 import ChartContext from '../ChartContext';
 import Scatter from '../Scatter/Scatter';
 
-function points(data, xKey) {
-  return data.map((d) => ({ [xKey]: d.data[xKey], y: d[1] }));
+function points(data, xValueSelector) {
+  return data.map((d) => ({ x: xValueSelector(d.data), y: d[1] }));
 }
 
 const Line = (props) => {
@@ -19,9 +19,9 @@ const Line = (props) => {
     markerShape: markerShapeContext,
     smoothed: smoothedContext,
     stacked,
-    xKey,
+    xValueSelector,
     xScale,
-    yKey,
+    yValueSelector,
     yScale,
   } = useContext(ChartContext) as any;
 
@@ -55,27 +55,27 @@ const Line = (props) => {
     linePath = d3
       .line()
       // @ts-ignore TODO: Fix me
-      .x((d) => xScale(d.data[xKey]))
+      .x((d) => xScale(xValueSelector(d.data)))
       .y((d) => -yScale(d[1]));
 
     areaPath = d3
       .area()
       // @ts-ignore TODO: Fix me
-      .x((d) => xScale(d.data[xKey]))
+      .x((d) => xScale(xValueSelector(d.data)))
       .y0((d) => -yScale(d[0]))
       .y1((d) => -yScale(d[1]));
 
-    pointData = points(chartData, xKey);
+    pointData = points(chartData, xValueSelector);
   } else {
     linePath = d3
       .line()
-      .x((d) => xScale(d[xKey]))
-      .y((d) => -yScale(d[yKey]));
+      .x((d) => xScale(xValueSelector(d)))
+      .y((d) => -yScale(yValueSelector(d)));
 
     areaPath = d3
       .area()
-      .x((d) => xScale(d[xKey]))
-      .y1((d) => -yScale(d[yKey]))
+      .x((d) => xScale(xValueSelector(d)))
+      .y1((d) => -yScale(yValueSelector(d)))
       .y0(-yScale(yScale.domain()[0]));
   }
 


### PR DESCRIPTION
This gives the possibility to use a function to select data for x/y axes. The previous way (field selection by string) is still possible.