### PR TITLE
[Charts] Observe component itself / Use fixed height or compute height based on ratio

### DIFF
--- a/docs/src/pages/components/charts/bar-chart/BasicBarChart.js
+++ b/docs/src/pages/components/charts/bar-chart/BasicBarChart.js
@@ -33,21 +33,19 @@ export default function BasicBarChart() {
 
   const theme = useTheme();
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <BarChart
-        data={chartData}
-        xScaleType="linear"
-        xDomain={[0, 23]}
-        label="Commits to the MUI repo by hour of day"
-        tickSpacing={30}
-        padding={5}
-        margin={{ top: 60 }}
-      >
-        <Grid disableX />
-        <XAxis />
-        <YAxis />
-        <Bar stroke="rgb(235,97,97)" fill={theme.palette.primary.main} />
-      </BarChart>
-    </div>
+    <BarChart
+      data={chartData}
+      xScaleType="linear"
+      xDomain={[0, 23]}
+      label="Commits to the MUI repo by hour of day"
+      tickSpacing={30}
+      padding={5}
+      margin={{ top: 60 }}
+    >
+      <Grid disableX />
+      <XAxis />
+      <YAxis />
+      <Bar stroke="rgb(235,97,97)" fill={theme.palette.primary.main} />
+    </BarChart>
   );
 }

--- a/docs/src/pages/components/charts/bar-chart/MultiBarChart.js
+++ b/docs/src/pages/components/charts/bar-chart/MultiBarChart.js
@@ -63,25 +63,23 @@ export default function MultiLineChart() {
   }, []);
 
   return chartData ? (
-    <div style={{ width: '100%', height: 400 }}>
-      <BarChart
-        data={[chartData?.morning, chartData?.afternoon, chartData?.night]}
-        highlightMarkers
-        invertMarkers
-        label="Commits to the MUI repo by day of week"
-        margin={{ top: 60, bottom: 70, left: 60 }}
-        xScaleType="linear"
-        padding={15}
-      >
-        <Grid disableX />
-        <Bar series={0} label="Morning" fill="rgb(116,205,240)" />
-        <Bar series={1} label="Afternoon" fill="rgb(150,219,124)" />
-        <Bar series={2} label="Night" fill="rgb(234,95,95)" />
-        <XAxis label="Day of week" />
-        <YAxis label="Count" disableLine disableTicks />
-        <Tooltip />
-        <Legend spacing={80} position="bottom" />
-      </BarChart>
-    </div>
+    <BarChart
+      data={[chartData?.morning, chartData?.afternoon, chartData?.night]}
+      highlightMarkers
+      invertMarkers
+      label="Commits to the MUI repo by day of week"
+      margin={{ top: 60, bottom: 70, left: 60 }}
+      xScaleType="linear"
+      padding={15}
+    >
+      <Grid disableX />
+      <Bar series={0} label="Morning" fill="rgb(116,205,240)" />
+      <Bar series={1} label="Afternoon" fill="rgb(150,219,124)" />
+      <Bar series={2} label="Night" fill="rgb(234,95,95)" />
+      <XAxis label="Day of week" />
+      <YAxis label="Count" disableLine disableTicks />
+      <Tooltip />
+      <Legend spacing={80} position="bottom" />
+    </BarChart>
   ) : null;
 }

--- a/docs/src/pages/components/charts/bar-chart/StackedBarChart.js
+++ b/docs/src/pages/components/charts/bar-chart/StackedBarChart.js
@@ -14,27 +14,25 @@ const stackData = [
 ];
 export default function StackedBarChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <BarChart
-        keys={['apples', 'bananas', 'oranges']}
-        data={stackData}
-        stacked
-        xScaleType="time"
-        xKey="month"
-        xDomain={[new Date(2021, 1, 1), new Date(2021, 4, 1)]}
-        yDomain={[0, 60]}
-        margin={{ top: 60, bottom: 70, left: 60 }}
-        label="Sales"
-        padding={20}
-      >
-        <Grid disableX />
-        <Bar series={2} label="MUI X Pro" fill="rgba(234,95,95,0.8)" />
-        <Bar series={1} label="Templates" fill="rgba(150,219,124,0.8)" />
-        <Bar series={0} label="Design kits" fill="rgba(116,205,240,0.8)" />
-        <XAxis />
-        <YAxis disableLine disableTicks label="USD (K)" />
-        <Legend position="bottom" spacing={76} />
-      </BarChart>
-    </div>
+    <BarChart
+      keys={['apples', 'bananas', 'oranges']}
+      data={stackData}
+      stacked
+      xScaleType="time"
+      xKey="month"
+      xDomain={[new Date(2021, 1, 1), new Date(2021, 4, 1)]}
+      yDomain={[0, 60]}
+      margin={{ top: 60, bottom: 70, left: 60 }}
+      label="Sales"
+      padding={20}
+    >
+      <Grid disableX />
+      <Bar series={2} label="MUI X Pro" fill="rgba(234,95,95,0.8)" />
+      <Bar series={1} label="Templates" fill="rgba(150,219,124,0.8)" />
+      <Bar series={0} label="Design kits" fill="rgba(116,205,240,0.8)" />
+      <XAxis />
+      <YAxis disableLine disableTicks label="USD (K)" />
+      <Legend position="bottom" spacing={76} />
+    </BarChart>
   );
 }

--- a/docs/src/pages/components/charts/line-chart/BasicLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/BasicLineChart.js
@@ -7,14 +7,12 @@ import Grid from '@mui/charts/Grid';
 
 export default function BasicLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
       <LineChart data={data} xScaleType="time" tickSpacing={62}>
         <Grid />
         <XAxis />
         <YAxis suffix="kg" />
         <Line stroke="rgb(235,97,97)" markerShape="none" />
       </LineChart>
-    </div>
   );
 }
 

--- a/docs/src/pages/components/charts/line-chart/FilledMultiLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/FilledMultiLineChart.js
@@ -8,36 +8,34 @@ import Legend from '@mui/charts/Legend';
 
 export default function FilledMultiLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart
-        data={[data1, data2]}
-        smoothed
-        label="Issues"
-        margin={{ top: 70, bottom: 70, left: 60 }}
-        markerShape="auto"
-        markerSize={40}
-        xScaleType="time"
-      >
-        <Grid disableX />
-        <XAxis label="Year" />
-        <YAxis label="Size" suffix="cm" disableLine disableTicks />
-        <Line
-          series={0}
-          stroke="rgb(116,205,240)"
-          fill="rgba(136,225,250,0.1)"
-          strokeWidth={2}
-          label="Open"
-        />
-        <Line
-          series={1}
-          stroke="rgb(150,219,124)"
-          fill="rgba(170,239,144,0.1)"
-          strokeWidth={2}
-          label="Closed"
-        />
-        <Legend position="bottom" spacing={55} />
-      </LineChart>
-    </div>
+    <LineChart
+      data={[data1, data2]}
+      smoothed
+      label="Issues"
+      margin={{ top: 70, bottom: 70, left: 60 }}
+      markerShape="auto"
+      markerSize={40}
+      xScaleType="time"
+    >
+      <Grid disableX />
+      <XAxis label="Year" />
+      <YAxis label="Size" suffix="cm" disableLine disableTicks />
+      <Line
+        series={0}
+        stroke="rgb(116,205,240)"
+        fill="rgba(136,225,250,0.1)"
+        strokeWidth={2}
+        label="Open"
+      />
+      <Line
+        series={1}
+        stroke="rgb(150,219,124)"
+        fill="rgba(170,239,144,0.1)"
+        strokeWidth={2}
+        label="Closed"
+      />
+      <Legend position="bottom" spacing={55} />
+    </LineChart>
   );
 }
 

--- a/docs/src/pages/components/charts/line-chart/GradientFilledMultiLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/GradientFilledMultiLineChart.js
@@ -27,32 +27,30 @@ const lineData2 = [
 
 export default function GradientFilledMultiLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart
-        data={[lineData1, lineData2]}
-        smoothed
-        label="Growth"
-        markerShape="none"
-        margin={{ top: 70, bottom: 60, left: 60 }}
-        xScaleType="time"
-        yDomain={null}
-      >
-        <defs>
-          <linearGradient id="color1" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="rgb(116,205,240)" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="rgb(116,205,240)" stopOpacity={0} />
-          </linearGradient>
-          <linearGradient id="color2" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
-          </linearGradient>
-        </defs>
-        <Grid disableX />
-        <XAxis label="Day of week" />
-        <YAxis label="Size" suffix="cm" disableLine disableTicks />
-        <Line series={0} stroke="rgb(116,205,240)" fill="url(#color1)" />
-        <Line series={1} stroke="rgb(150,219,124)" fill="url(#color2)" />
-      </LineChart>
-    </div>
+    <LineChart
+      data={[lineData1, lineData2]}
+      smoothed
+      label="Growth"
+      markerShape="none"
+      margin={{ top: 70, bottom: 60, left: 60 }}
+      xScaleType="time"
+      yDomain={null}
+    >
+      <defs>
+        <linearGradient id="color1" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="rgb(116,205,240)" stopOpacity={0.8} />
+          <stop offset="95%" stopColor="rgb(116,205,240)" stopOpacity={0} />
+        </linearGradient>
+        <linearGradient id="color2" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.8} />
+          <stop offset="95%" stopColor="#82ca9d" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <Grid disableX />
+      <XAxis label="Day of week" />
+      <YAxis label="Size" suffix="cm" disableLine disableTicks />
+      <Line series={0} stroke="rgb(116,205,240)" fill="url(#color1)" />
+      <Line series={1} stroke="rgb(150,219,124)" fill="url(#color2)" />
+    </LineChart>
   );
 }

--- a/docs/src/pages/components/charts/line-chart/LogScaleLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/LogScaleLineChart.js
@@ -18,20 +18,18 @@ const lineData1 = [
 
 export default function LogScaleLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart
-        smoothed
-        data={lineData1}
-        xScaleType="time"
-        yScaleType="log"
-        yDomain={null}
-      >
-        <Grid />
-        <Tooltip customStyle={{ borderRadius: 15 }} />
-        <XAxis />
-        <YAxis suffix="kg" />
-        <Line stroke="rgb(116,205,240)" />
-      </LineChart>
-    </div>
+    <LineChart
+      smoothed
+      data={lineData1}
+      xScaleType="time"
+      yScaleType="log"
+      yDomain={null}
+    >
+      <Grid />
+      <Tooltip customStyle={{ borderRadius: 15 }} />
+      <XAxis />
+      <YAxis suffix="kg" />
+      <Line stroke="rgb(116,205,240)" />
+    </LineChart>
   );
 }

--- a/docs/src/pages/components/charts/line-chart/MultiLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/MultiLineChart.js
@@ -39,26 +39,24 @@ const lineData3 = [
 
 export default function MultiLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart
-        data={[lineData1, lineData2, lineData3]}
-        highlightMarkers
-        invertMarkers
-        label="Growth"
-        margin={{ top: 70, bottom: 70, left: 60 }}
-        markerSize={50}
-        smoothed
-        xScaleType="time"
-      >
-        <Grid disableX />
-        <XAxis label="Year" />
-        <YAxis label="Size" suffix="cm" disableLine disableTicks />
-        <Tooltip />
-        <Line series={0} label="Blue" stroke="rgb(116,205,240)" strokeWidth={2} />
-        <Line series={1} label="Green" stroke="rgb(150,219,124)" strokeWidth={2} />
-        <Line series={2} label="Red" stroke="rgb(234,95,95)" strokeWidth={2} />
-        <Legend position="top" />
-      </LineChart>
-    </div>
+    <LineChart
+      data={[lineData1, lineData2, lineData3]}
+      highlightMarkers
+      invertMarkers
+      label="Growth"
+      margin={{ top: 70, bottom: 70, left: 60 }}
+      markerSize={50}
+      smoothed
+      xScaleType="time"
+    >
+      <Grid disableX />
+      <XAxis label="Year" />
+      <YAxis label="Size" suffix="cm" disableLine disableTicks />
+      <Tooltip />
+      <Line series={0} label="Blue" stroke="rgb(116,205,240)" strokeWidth={2} />
+      <Line series={1} label="Green" stroke="rgb(150,219,124)" strokeWidth={2} />
+      <Line series={2} label="Red" stroke="rgb(234,95,95)" strokeWidth={2} />
+      <Legend position="top" />
+    </LineChart>
   );
 }

--- a/docs/src/pages/components/charts/line-chart/SmoothedLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/SmoothedLineChart.js
@@ -17,13 +17,11 @@ const lineData1 = [
 
 export default function SmoothedLineChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart smoothed data={lineData1} xScaleType="time">
-        <Grid />
-        <XAxis />
-        <YAxis suffix="kg" />
-        <Line stroke="rgb(150,219,124)" markerShape="none" />
-      </LineChart>
-    </div>
+    <LineChart smoothed data={lineData1} xScaleType="time">
+      <Grid />
+      <XAxis />
+      <YAxis suffix="kg" />
+      <Line stroke="rgb(150,219,124)" markerShape="none" />
+    </LineChart>
   );
 }

--- a/docs/src/pages/components/charts/line-chart/StackedAreaChart.js
+++ b/docs/src/pages/components/charts/line-chart/StackedAreaChart.js
@@ -7,34 +7,32 @@ import Grid from '@mui/charts/Grid';
 
 export default function StackedAreaChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <LineChart
-        keys={['open', 'close']}
-        data={stackData}
-        smoothed
-        stacked
-        xScaleType="time"
-        xKey="date"
-        xDomain={[new Date(2020, 0, 1), new Date(2022, 9, 1)]}
-        yDomain={[0, 450]}
-      >
-        <Grid disableX />
-        <XAxis />
-        <YAxis />
-        <Line
-          series={1}
-          stroke="rgb(150,219,124)"
-          fill="rgba(150,219,124,0.5)"
-          strokeWidth={2}
-        />
-        <Line
-          series={0}
-          stroke="rgb(116,205,240)"
-          fill="rgba(116,205,240,0.5)"
-          strokeWidth={2}
-        />
-      </LineChart>
-    </div>
+    <LineChart
+      keys={['open', 'close']}
+      data={stackData}
+      smoothed
+      stacked
+      xScaleType="time"
+      xKey="date"
+      xDomain={[new Date(2020, 0, 1), new Date(2022, 9, 1)]}
+      yDomain={[0, 450]}
+    >
+      <Grid disableX />
+      <XAxis />
+      <YAxis />
+      <Line
+        series={1}
+        stroke="rgb(150,219,124)"
+        fill="rgba(150,219,124,0.5)"
+        strokeWidth={2}
+      />
+      <Line
+        series={0}
+        stroke="rgb(116,205,240)"
+        fill="rgba(116,205,240,0.5)"
+        strokeWidth={2}
+      />
+    </LineChart>
   );
 }
 

--- a/docs/src/pages/components/charts/line-chart/ZoomableLineChart.js
+++ b/docs/src/pages/components/charts/line-chart/ZoomableLineChart.js
@@ -64,7 +64,7 @@ export default function ZoomableLineChart() {
   }, [domain]);
 
   return (
-    <Stack style={{ width: '100%', height: 400 }}>
+    <Stack>
       <Box>
         <LineChart
           data={chartData}

--- a/docs/src/pages/components/charts/pie-chart/BasicPieChart.js
+++ b/docs/src/pages/components/charts/pie-chart/BasicPieChart.js
@@ -20,13 +20,11 @@ export default function BasicPieChart() {
   const data = generateData();
 
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <PieChart
-        data={data}
-        margin={{ top: 50, bottom: 20 }}
-        segmentLabelRadius={70}
-        label="Car sales"
-      />
-    </div>
+    <PieChart
+      data={data}
+      margin={{ top: 50, bottom: 20 }}
+      segmentLabelRadius={70}
+      label="Car sales"
+    />
   );
 }

--- a/docs/src/pages/components/charts/pie-chart/DonutChart.js
+++ b/docs/src/pages/components/charts/pie-chart/DonutChart.js
@@ -17,9 +17,5 @@ function generateData() {
 export default function DonutChart() {
   const data = generateData();
 
-  return (
-    <div style={{ width: '100%', height: 350 }}>
-      <PieChart data={data} innerRadius={90} innerLabel="Electric" />
-    </div>
-  );
+  return <PieChart data={data} innerRadius={90} innerLabel="Electric" />;
 }

--- a/docs/src/pages/components/charts/pie-chart/ExpandingPieChart.js
+++ b/docs/src/pages/components/charts/pie-chart/ExpandingPieChart.js
@@ -20,15 +20,13 @@ export default function ExpaindingPieChart() {
   const data = generateData();
 
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <PieChart
-        data={data}
-        expandOnHover
-        label="Car sales"
-        margin={{ top: 70, bottom: 20 }}
-        segmentLabelRadius={170}
-        sort="ascending"
-      />
-    </div>
+    <PieChart
+      data={data}
+      expandOnHover
+      label="Car sales"
+      margin={{ top: 70, bottom: 20 }}
+      segmentLabelRadius={170}
+      sort="ascending"
+    />
   );
 }

--- a/docs/src/pages/components/charts/pie-chart/PartialDonutChart.js
+++ b/docs/src/pages/components/charts/pie-chart/PartialDonutChart.js
@@ -15,15 +15,13 @@ const data = [
 
 export default function PartialDonutChart() {
   return (
-    <div style={{ width: '100%', height: 350 }}>
-      <PieChart
-        data={data}
-        innerRadius={110}
-        startAngle={-90}
-        endAngle={90}
-        fill="rgba(128, 128, 128, 0.2)"
-        innerLabel="66%"
-      />
-    </div>
+    <PieChart
+      data={data}
+      innerRadius={110}
+      startAngle={-90}
+      endAngle={90}
+      fill="rgba(128, 128, 128, 0.2)"
+      innerLabel="66%"
+    />
   );
 }

--- a/docs/src/pages/components/charts/scatter-chart/BasicScatterChart.js
+++ b/docs/src/pages/components/charts/scatter-chart/BasicScatterChart.js
@@ -16,13 +16,11 @@ const generateDataset = (xDomain, yDomain, zDomain) =>
 
 export default function MultiScatterChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <ScatterChart data={generateDataset([0, 20], [0, 50], [0, 5])}>
-        <Grid zeroStrokeDasharray="0" />
-        <Scatter fill="rgba(255,80,150,.5)" minSize={100} maxSize={100} />
-        <XAxis suffix="cm" disableTicks />
-        <YAxis suffix="kg" disableTicks />
-      </ScatterChart>
-    </div>
+    <ScatterChart data={generateDataset([0, 20], [0, 50], [0, 5])}>
+      <Grid zeroStrokeDasharray="0" />
+      <Scatter fill="rgba(255,80,150,.5)" minSize={100} maxSize={100} />
+      <XAxis suffix="cm" disableTicks />
+      <YAxis suffix="kg" disableTicks />
+    </ScatterChart>
   );
 }

--- a/docs/src/pages/components/charts/scatter-chart/MultiScatterChart.js
+++ b/docs/src/pages/components/charts/scatter-chart/MultiScatterChart.js
@@ -27,32 +27,30 @@ const domains2 = [
 
 export default function BasicScatterChart() {
   return (
-    <div style={{ width: '100%', height: 400 }}>
-      <ScatterChart
-        data={[generateDataset(...domains1), generateDataset(...domains2)]}
-        label="Mine vs Yours"
-        margin={{ top: 70 }}
-        markerShape="auto"
-        yDomain={null}
-      >
-        <Grid
-          strokeDasharray="5"
-          zeroStroke="rgba(200,200,200,0.5)"
-          zeroStrokeDasharray="0"
-        />
-        <Scatter
-          series={0}
-          stroke="rgba(255, 100, 0, 0.7)"
-          fill="rgba(255, 100, 0, 0.5)"
-        />
-        <Scatter
-          series={1}
-          stroke="rgba(0, 100, 255, 0.7)"
-          fill="rgba(0, 100, 255, 0.5)"
-        />
-        <XAxis suffix="cm" disableTicks />
-        <YAxis suffix="kg" disableTicks />
-      </ScatterChart>
-    </div>
+    <ScatterChart
+      data={[generateDataset(...domains1), generateDataset(...domains2)]}
+      label="Mine vs Yours"
+      margin={{ top: 70 }}
+      markerShape="auto"
+      yDomain={null}
+    >
+      <Grid
+        strokeDasharray="5"
+        zeroStroke="rgba(200,200,200,0.5)"
+        zeroStrokeDasharray="0"
+      />
+      <Scatter
+        series={0}
+        stroke="rgba(255, 100, 0, 0.7)"
+        fill="rgba(255, 100, 0, 0.5)"
+      />
+      <Scatter
+        series={1}
+        stroke="rgba(0, 100, 255, 0.7)"
+        fill="rgba(0, 100, 255, 0.5)"
+      />
+      <XAxis suffix="cm" disableTicks />
+      <YAxis suffix="kg" disableTicks />
+    </ScatterChart>
   );
 }

--- a/packages/charts/src/BarChart/BarChart.tsx
+++ b/packages/charts/src/BarChart/BarChart.tsx
@@ -7,7 +7,7 @@ import useStackedArrays from '../hooks/useStackedArrays';
 import useTicks from '../hooks/useTicks';
 import useScale from '../hooks/useScale';
 import useThrottle from '../hooks/useThrottle';
-import { getExtent, getMaxDataSetLength } from '../utils';
+import { getExtent, getMaxDataSetLength, stringRatioToNumber } from '../utils';
 
 interface ChartData<X, Y> {
   x: X;
@@ -61,6 +61,11 @@ export interface BarChartProps<X = unknown, Y = unknown> {
    * Labels and axes fall within these margins.
    */
   margin?: Margin;
+  /**
+   * The ratio of the height to the width of the chart.
+   * @default 0.5
+   */
+  ratio?: string | number;
   /**
    * The maximum number of pixels between tick marks.
    */
@@ -122,10 +127,12 @@ const BarChart = React.forwardRef(function BarChart<X = unknown, Y = unknown>(
     children,
     data: dataProp,
     fill = 'none',
+    height: heightProp,
     label,
     labelColor = 'currentColor',
     labelFontSize = 18,
     margin: marginProp,
+    ratio: ratioProp,
     tickSpacing = 40,
     seriesLabels = [],
     stacked = false,
@@ -151,6 +158,8 @@ const BarChart = React.forwardRef(function BarChart<X = unknown, Y = unknown>(
   }
 
   const margin = { top: 40, bottom: 40, left: 50, right: 30, ...marginProp };
+  const ratio = typeof ratioProp === 'string' ? stringRatioToNumber(ratioProp) : ratioProp || 0.5;
+
   const chartSettings = {
     marginTop: margin.top,
     marginRight: margin.right,
@@ -197,6 +206,7 @@ const BarChart = React.forwardRef(function BarChart<X = unknown, Y = unknown>(
       y: -1,
     });
   };
+  const chartHeight = heightProp || (width * ratio);
 
   return (
     <ChartContext.Provider
@@ -226,6 +236,7 @@ const BarChart = React.forwardRef(function BarChart<X = unknown, Y = unknown>(
         {...other}
         onMouseMove={handleMouseMove}
         onMouseOut={handleMouseOut}
+        style={{ width: '100%', height: chartHeight }}
       >
         <rect width={width} height={height} fill={fill} rx="4" />
         <g transform={`translate(${[marginLeft, marginTop].join(',')})`}>

--- a/packages/charts/src/LineChart/LineChart.tsx
+++ b/packages/charts/src/LineChart/LineChart.tsx
@@ -94,6 +94,10 @@ export interface LineChartProps<X = unknown, Y = unknown> {
    */
   markerSize?: number;
   /**
+   * The ratio of the width to the height of the chart.
+   */
+  ratio?: number;
+  /**
    * The maximum number of pixels per tick.
    */
   tickSpacing?: number;
@@ -147,6 +151,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
     data: dataProp,
     fill = 'none',
     highlightMarkers = false,
+    height: heightProp,
     id: idProp,
     invertMarkers = false,
     label,
@@ -155,6 +160,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
     margin: marginProp,
     markerShape = 'circle',
     markerSize = 30,
+    ratio = 2,
     tickSpacing = 50,
     smoothed = false,
     stacked = false,
@@ -242,7 +248,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
   };
 
   const chartId = useId(idProp);
-
+  const chartHeight = heightProp || Math.ceil(width / ratio);
   return (
     <ChartContext.Provider
       value={{
@@ -276,6 +282,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
         {...other}
         onMouseMove={handleMouseMove}
         onMouseOut={handleMouseOut}
+        style={{ width: '100%', height: chartHeight }}
       >
         <defs>
           <clipPath id={`${chartId}-clipPath`}>

--- a/packages/charts/src/LineChart/LineChart.tsx
+++ b/packages/charts/src/LineChart/LineChart.tsx
@@ -7,7 +7,7 @@ import useScale from '../hooks/useScale';
 import useStackedArrays from '../hooks/useStackedArrays';
 import useThrottle from '../hooks/useThrottle';
 import useTicks from '../hooks/useTicks';
-import { getExtent, getMaxDataSetLength } from '../utils';
+import { getExtent, getMaxDataSetLength, stringRatioToNumber } from '../utils';
 
 interface ChartData<X, Y> {
   x: X;
@@ -94,9 +94,10 @@ export interface LineChartProps<X = unknown, Y = unknown> {
    */
   markerSize?: number;
   /**
-   * The ratio of the width to the height of the chart.
+   * The ratio of the height to the width of the chart.
+   * @default 0.5
    */
-  ratio?: number;
+  ratio?: string | number;
   /**
    * The maximum number of pixels per tick.
    */
@@ -160,7 +161,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
     margin: marginProp,
     markerShape = 'circle',
     markerSize = 30,
-    ratio = 2,
+    ratio: ratioProp,
     tickSpacing = 50,
     smoothed = false,
     stacked = false,
@@ -185,6 +186,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
   }
 
   const margin = { top: 40, bottom: 40, left: 50, right: 30, ...marginProp };
+  const ratio = typeof ratioProp === 'string' ? stringRatioToNumber(ratioProp) : ratioProp || 0.5;
 
   const chartSettings = {
     marginTop: margin.top,
@@ -248,7 +250,7 @@ const LineChart = React.forwardRef(function LineChart<X = unknown, Y = unknown>(
   };
 
   const chartId = useId(idProp);
-  const chartHeight = heightProp || Math.ceil(width / ratio);
+  const chartHeight = heightProp || (width * ratio);
   return (
     <ChartContext.Provider
       value={{

--- a/packages/charts/src/PieChart/PieChart.tsx
+++ b/packages/charts/src/PieChart/PieChart.tsx
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import { useForkRef } from '@mui/material/utils';
 import useChartDimensions from '../hooks/useChartDimensions';
 import PieSegment from '../PieSegment';
+import { stringRatioToNumber } from '../utils';
 
 interface ChartData {
   value: number;
@@ -42,6 +43,10 @@ export interface PieChartProps {
    * Background fill color for the chart. Typically used when creating a guage.
    */
   fill?: string;
+  /**
+   * The height of the chart.
+   */
+  height?: number;
   /**
    * The label to place at the center of the chart. Typically used with `innerRadius` to create a gauge.
    */
@@ -83,6 +88,11 @@ export interface PieChartProps {
    */
   radius?: number;
   /**
+   * The ratio of the height to the width of the chart.
+   * @default 0.5
+   */
+  ratio?: string | number;
+  /**
    * The color of the segment labels.
    * @default 'currentColor'
    */
@@ -112,6 +122,7 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>(function PieChar
     endAngle: endAngleProp,
     expandOnHover = false,
     fill,
+    height: heightProp,
     innerLabel,
     innerLabelFontSize = 24,
     innerRadius = 0,
@@ -120,6 +131,7 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>(function PieChar
     labelFontSize = 18,
     margin: marginProp,
     radius: radiusProp,
+    ratio: ratioProp,
     segmentLabelColor = 'currentColor',
     segmentLabelFontSize = 12,
     segmentLabelRadius,
@@ -129,6 +141,7 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>(function PieChar
   } = props;
 
   const margin = { top: 10, bottom: 10, left: 10, right: 10, ...marginProp };
+  const ratio = typeof ratioProp === 'string' ? stringRatioToNumber(ratioProp) : ratioProp || 0.5;
 
   const chartSettings = {
     marginTop: margin.top,
@@ -154,7 +167,6 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>(function PieChar
   const endAngle = endAngleProp
     ? (((endAngleProp * Math.PI) / 180) * percentVisible) / 100
     : startAngle + ((((360 - startAngle) * Math.PI) / 180) * percentVisible) / 100;
-
   const pie = d3
     .pie()
     .startAngle(startAngle)
@@ -175,9 +187,15 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>(function PieChar
   }, [data]);
 
   const radius = radiusProp || Math.min(boundedWidth, boundedHeight) / 2;
+  const chartHeight = heightProp || width * ratio;
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} ref={handleRef} {...other}>
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      ref={handleRef}
+      style={{ width: '100%', height: chartHeight }}
+      {...other}
+    >
       <g
         transform={`translate(${boundedWidth / 2 + margin.left}, ${
           boundedHeight / 2 + margin.top

--- a/packages/charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/src/ScatterChart/ScatterChart.tsx
@@ -4,7 +4,7 @@ import ChartContext from '../ChartContext';
 import useChartDimensions from '../hooks/useChartDimensions';
 import useTicks from '../hooks/useTicks';
 import useScale from '../hooks/useScale';
-import { getExtent, getMaxDataSetLength } from '../utils';
+import { getExtent, getMaxDataSetLength, stringRatioToNumber } from '../utils';
 
 interface ChartData<X, Y> {
   x: X;
@@ -81,6 +81,11 @@ export interface ScatterChartProps<X = unknown, Y = unknown> {
    */
   markerSize?: number;
   /**
+   * The ratio of the height to the width of the chart.
+   * @default 0.5
+   */
+  ratio?: string | number;
+  /**
    * The maximum number of pixels per tick.
    */
   tickSpacing?: number;
@@ -136,12 +141,14 @@ const ScatterChart = React.forwardRef(function ScatterChart<X = unknown, Y = unk
     children,
     data,
     fill = 'none',
+    height: heightProp,
     invertMarkers = false,
     label,
     labelColor = 'currentColor',
     labelFontSize = 18,
     margin: marginProp,
     markerShape = 'circle',
+    ratio: ratioProp,
     tickSpacing = 50,
     xDomain: xDomainProp,
     xKey = 'x',
@@ -155,6 +162,7 @@ const ScatterChart = React.forwardRef(function ScatterChart<X = unknown, Y = unk
   } = props;
 
   const margin = { top: 40, bottom: 40, left: 50, right: 30, ...marginProp };
+  const ratio = typeof ratioProp === 'string' ? stringRatioToNumber(ratioProp) : ratioProp || 0.5;
   const chartSettings = {
     marginTop: margin.top,
     marginBottom: margin.bottom,
@@ -183,6 +191,7 @@ const ScatterChart = React.forwardRef(function ScatterChart<X = unknown, Y = unk
     tickSpacing,
     maxTicks: 999,
   });
+  const chartHeight = heightProp || (width * ratio);
 
   return (
     <ChartContext.Provider
@@ -201,7 +210,12 @@ const ScatterChart = React.forwardRef(function ScatterChart<X = unknown, Y = unk
         zKey,
       }}
     >
-      <svg viewBox={`0 0 ${width} ${height}`} ref={handleRef} {...other}>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        ref={handleRef}
+        {...other}
+        style={{ width: '100%', height: chartHeight }}
+      >
         <rect width={width} height={height} fill={fill} rx="4" />
         <g transform={`translate(${[marginLeft, marginTop].join(',')})`}>
           <g>{children}</g>

--- a/packages/charts/src/hooks/useChartDimensions.js
+++ b/packages/charts/src/hooks/useChartDimensions.js
@@ -35,7 +35,7 @@ const useChartDimensions = (settings) => {
       return [ref, dimensions];
     }
 
-    const element = ref.current.parentElement;
+    const element = ref.current;
     const resizeObserver = new ResizeObserver((entries) => {
       if (Array.isArray(entries) && entries.length) {
         const entry = entries[0];

--- a/packages/charts/src/utils.js
+++ b/packages/charts/src/utils.js
@@ -69,3 +69,11 @@ export function getSymbol(shape, series = 0) {
   }
   return symbolNames.indexOf(shape) || 0;
 }
+
+// Converts a ratio of string type to number
+// e.g., "1:2" to 0.5
+export function stringRatioToNumber(stringRatio) {
+  const arr = stringRatio.split(':').map((value) => Number(value.trim()));
+  const res = arr[0] / arr[1];
+  return arr.length === 2 && typeof res === 'number' ? res : 0.5;
+}


### PR DESCRIPTION
My idea is to receive `height` prop, which you already do, and `ratio` (of width to height of chart), set to 2 by default, and use either for the height of the chart: `height` or `width / ratio`. Currently, `height` overrides the other. This allows us to observe the svg element itself.