### PR TITLE
fix(x-studio): backlog items BL-201 to BL-205

### DIFF
--- a/examples/x-studio-shared/src/FeatureFlagSettings.tsx
+++ b/examples/x-studio-shared/src/FeatureFlagSettings.tsx
@@ -59,6 +59,8 @@ const TOP_LEVEL_FLAGS: {
   { key: 'relationships', label: 'Relationships panel', parentKey: 'dataManagement' },
   { key: 'widgetFilters', label: 'Widget filters tab' },
   { key: 'aiChat', label: 'AI chat assistant' },
+  { key: 'aiInsights', label: 'AI widget insights' },
+  { key: 'export', label: 'Widget export (CSV / PNG)' },
   { key: 'calculatedFields', label: 'Calculated fields (all)' },
 ];
 

--- a/packages/x-studio/BACKLOG.md
+++ b/packages/x-studio/BACKLOG.md
@@ -901,12 +901,22 @@ BL-199: Sales logistics page > Ontime shipments shows 0% with a flat trend. Fix 
 
 BL-200: Pipeline widget config: The select is smooshed to the left by the button group, and the botton group is too tall because of the arrows. put the select abouve the button group, and rearrange the buttons. Add an option for "natural". Make it a shared widget, and use it anywhere else that has the same broken ui as pipeline.
 
-BL:201: Sales products page has Avg Unit Margin and Total Inventory Value KPIs as $0
+✅ BL-201: Sales products page has Avg Unit Margin and Total Inventory Value KPIs as $0
 
-BL-202: Determine which features and sub-features that don't already should have a feature flag, and add them, including the settings dialog in the example apps.
+**Fixed** (root cause was the async adapter/server data path, not the demo config — the in-memory pipeline computes both KPIs correctly). Those KPIs use expression (calculated) value fields (`price - cost`, `stock * price`), which the server cannot project or aggregate. `buildQueryDescriptor` now expands expression columns to their native dependencies in `select` and drops expression-field aggregations (a computed-column aggregate is not a column aggregate), and `useWidgetRows` enriches the adapter-returned raw rows with expression columns client-side via `getCachedEnrichedRows`. Native-field KPIs are unaffected. New `expandToNativeFields` export plus regression tests in `queryDescriptor.test.ts`.
 
-BL-203: Compact numbers are longer than not for whole values, eg $40.0 rather than $40
+✅ BL-202: Determine which features and sub-features that don't already should have a feature flag, and add them, including the settings dialog in the example apps.
 
-BL-204: The toggle chips clear button makes the widget taller. Put it immediately to the right of the last chip instead.
+**Fixed** (added two embedder-facing flags that previously had no toggle: `aiInsights` — the per-widget AI insight button and chart anomaly detection/explanation, gated independently of `aiChat`; and `export` — the widget CSV/PNG export action. Both resolved in `useStudioFeatures()` (default `true`), gated in `StudioWidgetCard`, and exposed as toggles in the shared `FeatureFlagSettings` used by both example apps.)
 
-BL-205: Move table conditional formatting to the format tab
+✅ BL-203: Compact numbers are longer than not for whole values, eg $40.0 rather than $40
+
+**Fixed** (compact currency formatting forced `minimumFractionDigits: 1`, adding a trailing `.0` to whole values. `getCurrencyFormat` now decouples the bounds — `minimumFractionDigits: 0`, `maximumFractionDigits: 1` for compact — so `$40` stays `$40` while `$40.5K` keeps its digit. An explicit precision still pins both bounds.)
+
+✅ BL-204: The toggle chips clear button makes the widget taller. Put it immediately to the right of the last chip instead.
+
+**Fixed** (the clear button moved out of its own top row into the chips flex container as the last item, so it wraps inline with the chips and no longer adds a dedicated row.)
+
+✅ BL-205: Move table conditional formatting to the format tab
+
+**Fixed** (extracted the conditional-formatting rule editor into `GridConditionalFormatSection` and rendered it from `FormatPanel` (the Format tab) instead of `GridSetupPanel` (Setup tab); removed the now-unused presets/operators and imports from `GridSetupPanel`. The `gridConditionalFormats` feature flag is still respected.)

--- a/packages/x-studio/src/components/StudioCanvas/StudioQuickFilterBar.test.tsx
+++ b/packages/x-studio/src/components/StudioCanvas/StudioQuickFilterBar.test.tsx
@@ -33,6 +33,8 @@ const BASE_FEATURES: ResolvedStudioFeatures = {
   relationships: true,
   widgetFilters: true,
   aiChat: false,
+  aiInsights: true,
+  export: true,
   grid: true,
   chart: true,
   kpi: true,

--- a/packages/x-studio/src/components/StudioComposeDrawer/FormatPanel.tsx
+++ b/packages/x-studio/src/components/StudioComposeDrawer/FormatPanel.tsx
@@ -25,6 +25,7 @@ import {
   useStudioLocaleText,
 } from '../../context';
 import { inferWidgetTitles, inferKpiDateSubtitle } from '../../internals/widgetUtils';
+import { GridConditionalFormatSection } from './GridConditionalFormatSection';
 
 export function FormatPanel(props: { widgetId: string }) {
   const { widgetId } = props;
@@ -220,20 +221,23 @@ export function FormatPanel(props: { widgetId: string }) {
         />
       )}
       {widget?.kind === 'grid' && (
-        <TextField
-          label={localeText.gridSetupHeightLabel}
-          type="number"
-          size="small"
-          fullWidth
-          value={widget.config.gridHeight ?? 400}
-          slotProps={{ htmlInput: { min: 200, step: 50 } }}
-          onChange={(event) => {
-            const parsed = parseInt(event.target.value, 10);
-            if (!Number.isNaN(parsed) && parsed >= 200) {
-              controller.updateWidgetConfig(widgetId, { gridHeight: parsed });
-            }
-          }}
-        />
+        <React.Fragment>
+          <TextField
+            label={localeText.gridSetupHeightLabel}
+            type="number"
+            size="small"
+            fullWidth
+            value={widget.config.gridHeight ?? 400}
+            slotProps={{ htmlInput: { min: 200, step: 50 } }}
+            onChange={(event) => {
+              const parsed = parseInt(event.target.value, 10);
+              if (!Number.isNaN(parsed) && parsed >= 200) {
+                controller.updateWidgetConfig(widgetId, { gridHeight: parsed });
+              }
+            }}
+          />
+          <GridConditionalFormatSection widgetId={widgetId} />
+        </React.Fragment>
       )}
       {widget?.kind === 'map' &&
         (() => {

--- a/packages/x-studio/src/components/StudioComposeDrawer/GridConditionalFormatSection.tsx
+++ b/packages/x-studio/src/components/StudioComposeDrawer/GridConditionalFormatSection.tsx
@@ -1,0 +1,208 @@
+'use client';
+import * as React from 'react';
+import { Box, Button, IconButton, MenuItem, Select, Stack, TextField } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { StudioConditionalFormat } from '../../models';
+import {
+  useStudioController,
+  useStudioSelector,
+  selectWidgets,
+  selectDataSources,
+  useStudioLocaleText,
+} from '../../context';
+import { useStudioFeatures } from '../../internals/StudioUIConfigContext';
+import { SetupSection } from './SetupSection';
+
+/**
+ * Grid (table) conditional-formatting rule editor. Lives in the widget's **Format** tab
+ * (rule-based cell colouring is a presentation concern, not a data-setup one). Renders
+ * nothing when the source is unresolved or the `gridConditionalFormats` feature is off.
+ */
+export function GridConditionalFormatSection(props: { widgetId: string }) {
+  const { widgetId } = props;
+  const controller = useStudioController();
+  const features = useStudioFeatures();
+  const widget = useStudioSelector(selectWidgets)[widgetId];
+  const dataSources = useStudioSelector(selectDataSources);
+  const localeText = useStudioLocaleText();
+
+  const source = widget?.sourceId ? dataSources[widget.sourceId] : undefined;
+
+  const cfOperators: { value: StudioConditionalFormat['operator']; label: string }[] = [
+    { value: 'equals', label: '=' },
+    { value: 'not_equals', label: '≠' },
+    { value: 'greater_than', label: '>' },
+    { value: 'greater_than_or_equal', label: '≥' },
+    { value: 'less_than', label: '<' },
+    { value: 'less_than_or_equal', label: '≤' },
+    { value: 'contains', label: localeText.gridSetupCFContains },
+    { value: 'is_empty', label: localeText.gridSetupCFIsEmpty },
+    { value: 'is_not_empty', label: localeText.gridSetupCFNotEmpty },
+  ];
+  const cfStylePresets: { label: string; style: StudioConditionalFormat['style'] }[] = [
+    {
+      label: localeText.gridSetupCFStyleRed,
+      style: { backgroundColor: '#ffcdd2', color: '#b71c1c' },
+    },
+    {
+      label: localeText.gridSetupCFStyleGreen,
+      style: { backgroundColor: '#c8e6c9', color: '#1b5e20' },
+    },
+    {
+      label: localeText.gridSetupCFStyleYellow,
+      style: { backgroundColor: '#fff9c4', color: '#f57f17' },
+    },
+    {
+      label: localeText.gridSetupCFStyleBlue,
+      style: { backgroundColor: '#bbdefb', color: '#0d47a1' },
+    },
+    { label: localeText.gridSetupCFStyleBold, style: { fontWeight: 'bold' } },
+  ];
+
+  if (!source || features.gridConditionalFormats === false) {
+    return null;
+  }
+
+  const conditionalFormats: StudioConditionalFormat[] =
+    widget?.config?.gridConditionalFormats ?? [];
+
+  return (
+    <SetupSection title={localeText.gridSetupConditionalFormattingTitle}>
+      <Stack spacing={1}>
+        {conditionalFormats.map((rule, i) => {
+          const noValueOp = rule.operator === 'is_empty' || rule.operator === 'is_not_empty';
+          const fieldEntry = source.fields.find((f) => f.id === rule.fieldId);
+          const preset = cfStylePresets.find(
+            (p) =>
+              p.style.backgroundColor === rule.style.backgroundColor &&
+              p.style.color === rule.style.color &&
+              p.style.fontWeight === rule.style.fontWeight,
+          );
+          return (
+            // react-doctor-disable-next-line react-doctor/no-array-index-as-key, react-doctor/no-array-index-key -- conditional format rules have no stable ID
+            <Box key={i} sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexWrap: 'wrap' }}>
+              <Select
+                size="small"
+                value={rule.fieldId}
+                aria-label={localeText.gridConditionFieldAriaLabel}
+                onChange={(event) => {
+                  const next = [...conditionalFormats];
+                  next[i] = { ...rule, fieldId: event.target.value };
+                  controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
+                }}
+                sx={{ fontSize: 12, flex: '1 1 80px', minWidth: 60 }}
+              >
+                {source.fields.map((f) => (
+                  <MenuItem key={f.id} value={f.id} dense sx={{ fontSize: 12 }}>
+                    {f.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Select
+                size="small"
+                value={rule.operator}
+                aria-label={localeText.gridConditionOperatorAriaLabel}
+                onChange={(event) => {
+                  const next = [...conditionalFormats];
+                  next[i] = {
+                    ...rule,
+                    operator: event.target.value as StudioConditionalFormat['operator'],
+                  };
+                  controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
+                }}
+                sx={{ fontSize: 12, flex: '0 0 auto', minWidth: 60 }}
+              >
+                {cfOperators.map((op) => (
+                  <MenuItem key={op.value} value={op.value} dense sx={{ fontSize: 12 }}>
+                    {op.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!noValueOp && (
+                <TextField
+                  size="small"
+                  value={rule.value !== undefined && rule.value !== null ? String(rule.value) : ''}
+                  placeholder={fieldEntry?.type === 'number' ? '0' : 'value'}
+                  slotProps={{
+                    htmlInput: { 'aria-label': localeText.gridConditionValueAriaLabel },
+                  }}
+                  onChange={(event) => {
+                    const next = [...conditionalFormats];
+                    const v =
+                      fieldEntry?.type === 'number'
+                        ? Number(event.target.value)
+                        : event.target.value;
+                    next[i] = { ...rule, value: v };
+                    controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
+                  }}
+                  sx={{ flex: '1 1 60px', minWidth: 48, '& input': { fontSize: 12 } }}
+                />
+              )}
+              <Select
+                size="small"
+                value={preset?.label ?? '__custom__'}
+                aria-label={localeText.gridConditionStyleAriaLabel}
+                onChange={(event) => {
+                  const selected = cfStylePresets.find((p) => p.label === event.target.value);
+                  if (selected) {
+                    const next = [...conditionalFormats];
+                    next[i] = { ...rule, style: selected.style };
+                    controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
+                  }
+                }}
+                sx={{ fontSize: 12, flex: '0 0 auto', minWidth: 64 }}
+              >
+                {cfStylePresets.map((p) => (
+                  <MenuItem key={p.label} value={p.label} dense sx={{ fontSize: 12 }}>
+                    {p.label}
+                  </MenuItem>
+                ))}
+                {!preset && (
+                  <MenuItem value="__custom__" dense sx={{ fontSize: 12 }}>
+                    {localeText.gridSetupConditionalCustom}
+                  </MenuItem>
+                )}
+              </Select>
+              <IconButton
+                size="small"
+                aria-label={localeText.gridSetupRemoveRuleAriaLabel}
+                onClick={() => {
+                  const next = conditionalFormats.filter((_, j) => j !== i);
+                  controller.updateWidgetConfig(widgetId, {
+                    gridConditionalFormats: next.length > 0 ? next : undefined,
+                  });
+                }}
+              >
+                <DeleteIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Box>
+          );
+        })}
+        <Button
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            const firstField = source.fields[0];
+            if (!firstField) {
+              return;
+            }
+            const next: StudioConditionalFormat[] = [
+              ...conditionalFormats,
+              {
+                fieldId: firstField.id,
+                operator: 'greater_than',
+                value: 0,
+                style: cfStylePresets[0].style,
+              },
+            ];
+            controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
+          }}
+          sx={{ alignSelf: 'flex-start', fontSize: 12 }}
+        >
+          {localeText.gridSetupAddRule}
+        </Button>
+      </Stack>
+    </SetupSection>
+  );
+}

--- a/packages/x-studio/src/components/StudioComposeDrawer/GridSetupPanel.tsx
+++ b/packages/x-studio/src/components/StudioComposeDrawer/GridSetupPanel.tsx
@@ -11,7 +11,6 @@ import {
   ListSubheader,
   Menu,
   MenuItem,
-  Select,
   Stack,
   TextField,
   ToggleButton,
@@ -30,7 +29,6 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import type {
-  StudioConditionalFormat,
   StudioCrossFilterMode,
   StudioGridColumn,
   StudioGridSummaryAggregation,
@@ -92,37 +90,6 @@ export function GridSetupPanel(props: { widgetId: string }) {
     min: localeText.aggFnMin,
     max: localeText.aggFnMax,
   };
-  const cfOperators: { value: StudioConditionalFormat['operator']; label: string }[] = [
-    { value: 'equals', label: '=' },
-    { value: 'not_equals', label: '≠' },
-    { value: 'greater_than', label: '>' },
-    { value: 'greater_than_or_equal', label: '≥' },
-    { value: 'less_than', label: '<' },
-    { value: 'less_than_or_equal', label: '≤' },
-    { value: 'contains', label: localeText.gridSetupCFContains },
-    { value: 'is_empty', label: localeText.gridSetupCFIsEmpty },
-    { value: 'is_not_empty', label: localeText.gridSetupCFNotEmpty },
-  ];
-  const cfStylePresets: { label: string; style: StudioConditionalFormat['style'] }[] = [
-    {
-      label: localeText.gridSetupCFStyleRed,
-      style: { backgroundColor: '#ffcdd2', color: '#b71c1c' },
-    },
-    {
-      label: localeText.gridSetupCFStyleGreen,
-      style: { backgroundColor: '#c8e6c9', color: '#1b5e20' },
-    },
-    {
-      label: localeText.gridSetupCFStyleYellow,
-      style: { backgroundColor: '#fff9c4', color: '#f57f17' },
-    },
-    {
-      label: localeText.gridSetupCFStyleBlue,
-      style: { backgroundColor: '#bbdefb', color: '#0d47a1' },
-    },
-    { label: localeText.gridSetupCFStyleBold, style: { fontWeight: 'bold' } },
-  ];
-
   const source = widget?.sourceId ? dataSources[widget.sourceId] : undefined;
 
   // configColumns: the current StudioGridColumn[] from widget config, or default all-primary-fields
@@ -314,8 +281,6 @@ export function GridSetupPanel(props: { widgetId: string }) {
     widget?.config?.gridAggregations ?? {};
   const sortField = widget?.config?.gridSortField ?? '';
   const sortDirection = widget?.config?.gridSortDirection ?? 'asc';
-  const conditionalFormats: StudioConditionalFormat[] =
-    widget?.config?.gridConditionalFormats ?? [];
 
   const availableSources = React.useMemo(
     () => Object.values(dataSources).filter((s) => !s.hidden),
@@ -763,152 +728,7 @@ export function GridSetupPanel(props: { widgetId: string }) {
         </React.Fragment>
       )}
 
-      {source && features.gridConditionalFormats !== false && (
-        <React.Fragment>
-          {/* Conditional formatting rules */}
-          <SetupSection title={localeText.gridSetupConditionalFormattingTitle}>
-            <Stack spacing={1}>
-              {conditionalFormats.map((rule, i) => {
-                const noValueOp = rule.operator === 'is_empty' || rule.operator === 'is_not_empty';
-                const fieldEntry = source.fields.find((f) => f.id === rule.fieldId);
-                const preset = cfStylePresets.find(
-                  (p) =>
-                    p.style.backgroundColor === rule.style.backgroundColor &&
-                    p.style.color === rule.style.color &&
-                    p.style.fontWeight === rule.style.fontWeight,
-                );
-                return (
-                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key, react-doctor/no-array-index-key -- conditional format rules have no stable ID
-                  <Box
-                    key={i}
-                    sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexWrap: 'wrap' }}
-                  >
-                    <Select
-                      size="small"
-                      value={rule.fieldId}
-                      aria-label={localeText.gridConditionFieldAriaLabel}
-                      onChange={(event) => {
-                        const next = [...conditionalFormats];
-                        next[i] = { ...rule, fieldId: event.target.value };
-                        controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
-                      }}
-                      sx={{ fontSize: 12, flex: '1 1 80px', minWidth: 60 }}
-                    >
-                      {source.fields.map((f) => (
-                        <MenuItem key={f.id} value={f.id} dense sx={{ fontSize: 12 }}>
-                          {f.label}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <Select
-                      size="small"
-                      value={rule.operator}
-                      aria-label={localeText.gridConditionOperatorAriaLabel}
-                      onChange={(event) => {
-                        const next = [...conditionalFormats];
-                        next[i] = {
-                          ...rule,
-                          operator: event.target.value as StudioConditionalFormat['operator'],
-                        };
-                        controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
-                      }}
-                      sx={{ fontSize: 12, flex: '0 0 auto', minWidth: 60 }}
-                    >
-                      {cfOperators.map((op) => (
-                        <MenuItem key={op.value} value={op.value} dense sx={{ fontSize: 12 }}>
-                          {op.label}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    {!noValueOp && (
-                      <TextField
-                        size="small"
-                        value={
-                          rule.value !== undefined && rule.value !== null ? String(rule.value) : ''
-                        }
-                        placeholder={fieldEntry?.type === 'number' ? '0' : 'value'}
-                        slotProps={{
-                          htmlInput: { 'aria-label': localeText.gridConditionValueAriaLabel },
-                        }}
-                        onChange={(event) => {
-                          const next = [...conditionalFormats];
-                          const v =
-                            fieldEntry?.type === 'number'
-                              ? Number(event.target.value)
-                              : event.target.value;
-                          next[i] = { ...rule, value: v };
-                          controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
-                        }}
-                        sx={{ flex: '1 1 60px', minWidth: 48, '& input': { fontSize: 12 } }}
-                      />
-                    )}
-                    <Select
-                      size="small"
-                      value={preset?.label ?? '__custom__'}
-                      aria-label={localeText.gridConditionStyleAriaLabel}
-                      onChange={(event) => {
-                        const selected = cfStylePresets.find((p) => p.label === event.target.value);
-                        if (selected) {
-                          const next = [...conditionalFormats];
-                          next[i] = { ...rule, style: selected.style };
-                          controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
-                        }
-                      }}
-                      sx={{ fontSize: 12, flex: '0 0 auto', minWidth: 64 }}
-                    >
-                      {cfStylePresets.map((p) => (
-                        <MenuItem key={p.label} value={p.label} dense sx={{ fontSize: 12 }}>
-                          {p.label}
-                        </MenuItem>
-                      ))}
-                      {!preset && (
-                        <MenuItem value="__custom__" dense sx={{ fontSize: 12 }}>
-                          {localeText.gridSetupConditionalCustom}
-                        </MenuItem>
-                      )}
-                    </Select>
-                    <IconButton
-                      size="small"
-                      aria-label={localeText.gridSetupRemoveRuleAriaLabel}
-                      onClick={() => {
-                        const next = conditionalFormats.filter((_, j) => j !== i);
-                        controller.updateWidgetConfig(widgetId, {
-                          gridConditionalFormats: next.length > 0 ? next : undefined,
-                        });
-                      }}
-                    >
-                      <DeleteIcon sx={{ fontSize: 14 }} />
-                    </IconButton>
-                  </Box>
-                );
-              })}
-              <Button
-                size="small"
-                startIcon={<AddIcon />}
-                onClick={() => {
-                  const firstField = source.fields[0];
-                  if (!firstField) {
-                    return;
-                  }
-                  const next: StudioConditionalFormat[] = [
-                    ...conditionalFormats,
-                    {
-                      fieldId: firstField.id,
-                      operator: 'greater_than',
-                      value: 0,
-                      style: cfStylePresets[0].style,
-                    },
-                  ];
-                  controller.updateWidgetConfig(widgetId, { gridConditionalFormats: next });
-                }}
-                sx={{ alignSelf: 'flex-start', fontSize: 12 }}
-              >
-                {localeText.gridSetupAddRule}
-              </Button>
-            </Stack>
-          </SetupSection>
-        </React.Fragment>
-      )}
+      {/* Conditional formatting now lives in the Format tab (see GridConditionalFormatSection). */}
 
       {source && (
         <React.Fragment>

--- a/packages/x-studio/src/components/StudioWidgetCard/StudioWidgetCard.tsx
+++ b/packages/x-studio/src/components/StudioWidgetCard/StudioWidgetCard.tsx
@@ -42,6 +42,7 @@ import {
 import { StudioWidgetCardActionsOverlay } from './StudioWidgetCardActionsOverlay';
 import { moveWidgetInLayout, type WidgetMoveDirection } from '../../internals/widgetLayoutMove';
 import { useStudioAnnounce } from '../../internals/StudioLiveRegion';
+import { useStudioFeatures } from '../../internals/StudioUIConfigContext';
 import { StudioWidgetEditDialog } from '../StudioWidgetEditDialog';
 import type { StudioPageTheme } from '../../models';
 import { StudioGridWidget } from '../widgets/StudioGridWidget/StudioGridWidget';
@@ -200,6 +201,7 @@ export const StudioWidgetCard = React.memo(function StudioWidgetCard(props: Stud
   const localeText = useStudioLocaleText();
   const customWidgetMap = useCustomWidgetMap();
   const { aiConfig } = useStudioUIConfig();
+  const features = useStudioFeatures();
 
   // For KPI widgets with auto subtitle and no user-set subtitle, derive a date range label
   // dynamically from the active date filters so it always reflects current filter state.
@@ -223,8 +225,10 @@ export const StudioWidgetCard = React.memo(function StudioWidgetCard(props: Stud
   // Full-bleed custom widgets render edge-to-edge: no title/subtitle header and no card padding.
   const isFullBleedCustom = customDef?.fullBleed === true;
 
-  // AI insights are disabled for filter/text/kpi widgets; custom widgets opt in via `aiInsight: true`
+  // AI insights are disabled for filter/text/kpi widgets; custom widgets opt in via `aiInsight: true`.
+  // The `aiInsights` feature flag lets embedders hide per-widget AI actions independently of AI chat.
   const supportsInsight =
+    features.aiInsights &&
     widget != null &&
     widget.kind !== 'filter' &&
     widget.kind !== 'text' &&
@@ -490,7 +494,9 @@ export const StudioWidgetCard = React.memo(function StudioWidgetCard(props: Stud
     return null;
   }
 
-  const canExport = widget.kind === 'grid' || widget.kind === 'chart' || widget.kind === 'pivot';
+  const canExport =
+    features.export &&
+    (widget.kind === 'grid' || widget.kind === 'chart' || widget.kind === 'pivot');
   const isChart = widget.kind === 'chart';
   const showEditActions = mode === 'edit' && (isSelected || (!dimmed && hovered));
   const showViewExport = mode === 'view' && hovered && canExport;
@@ -586,7 +592,7 @@ export const StudioWidgetCard = React.memo(function StudioWidgetCard(props: Stud
           }
           anomalyEnabled={anomalyEnabled}
           anomalyCount={anomalyAnnotations.length}
-          onAnomalyToggle={isChart ? handleAnomalyToggle : undefined}
+          onAnomalyToggle={isChart && features.aiInsights ? handleAnomalyToggle : undefined}
           onAnomalyExplain={
             isChart && aiConfig?.endpoint && anomalyEnabled && anomalyAnnotations.length > 0
               ? handleAnomalyExplain

--- a/packages/x-studio/src/components/widgets/StudioFilterWidget/controls/ToggleControl.tsx
+++ b/packages/x-studio/src/components/widgets/StudioFilterWidget/controls/ToggleControl.tsx
@@ -46,20 +46,6 @@ export function ToggleControl(props: StudioFilterToggleControlProps) {
 
   return (
     <Stack spacing={1} role="group" aria-label={label}>
-      {isActive && (
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Tooltip title={localeText.filterWidgetClearAriaLabel}>
-            <IconButton
-              size="small"
-              aria-label={localeText.filterWidgetClearAriaLabel}
-              onClick={onClear}
-              sx={{ color: 'text.secondary', p: 0.5 }}
-            >
-              <CloseIcon sx={{ fontSize: 14 }} />
-            </IconButton>
-          </Tooltip>
-        </Box>
-      )}
       {showSearch && (
         <TextField
           size="small"
@@ -79,7 +65,7 @@ export function ToggleControl(props: StudioFilterToggleControlProps) {
         />
       )}
       {filtered.length > 0 ? (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.75 }}>
           {filtered.map((v) => (
             <Chip
               key={v}
@@ -90,6 +76,20 @@ export function ToggleControl(props: StudioFilterToggleControlProps) {
               aria-pressed={selected.includes(v)}
             />
           ))}
+          {/* Clear sits inline as the last item so it wraps with the chips and never
+              adds a dedicated row (which would make the widget taller). */}
+          {isActive && (
+            <Tooltip title={localeText.filterWidgetClearAriaLabel}>
+              <IconButton
+                size="small"
+                aria-label={localeText.filterWidgetClearAriaLabel}
+                onClick={onClear}
+                sx={{ color: 'text.secondary', p: 0.25 }}
+              >
+                <CloseIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
         </Box>
       ) : (
         <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>

--- a/packages/x-studio/src/internals/StudioUIConfigContext.ts
+++ b/packages/x-studio/src/internals/StudioUIConfigContext.ts
@@ -1988,6 +1988,8 @@ export interface ResolvedStudioFeatures {
   relationships: boolean;
   widgetFilters: boolean;
   aiChat: boolean;
+  aiInsights: boolean;
+  export: boolean;
   // ── Widget kind availability ───────────────────────────────────────────────
   grid: boolean;
   chart: boolean;
@@ -2045,6 +2047,8 @@ export function useStudioFeatures(): ResolvedStudioFeatures {
     relationships: featureFlags.relationships ?? true,
     widgetFilters: featureFlags.widgetFilters ?? true,
     aiChat: featureFlags.aiChat ?? true,
+    aiInsights: featureFlags.aiInsights ?? true,
+    export: featureFlags.export ?? true,
     // Widget kinds: enabled when the flag is not `false` (true, undefined, or an object all enable the kind)
     grid: grid !== false,
     chart: chart !== false,

--- a/packages/x-studio/src/internals/numberFormat.test.ts
+++ b/packages/x-studio/src/internals/numberFormat.test.ts
@@ -89,6 +89,16 @@ describe('formatNumber — currency format', () => {
   it('compact: abbreviates with K/M suffix', () => {
     expect(formatNumber(2_000_000, 'currency', 'USD', true)).toMatch(/M/i);
   });
+
+  it('compact: does not append a trailing .0 to whole values', () => {
+    // Whole value → no fractional part (e.g. "$40", not "$40.0")
+    expect(formatNumber(40, 'currency', 'USD', true)).not.toMatch(/[.,]\d/);
+  });
+
+  it('compact: keeps up to 1 fraction digit for non-whole abbreviations', () => {
+    // 40,500 → "$40.5K": the fractional digit is preserved
+    expect(formatNumber(40_500, 'currency', 'USD', true)).toMatch(/[.,]5K/i);
+  });
 });
 
 describe('formatNumber — default format (no format argument)', () => {

--- a/packages/x-studio/src/internals/numberFormat.ts
+++ b/packages/x-studio/src/internals/numberFormat.ts
@@ -65,15 +65,18 @@ function getCurrencyFormat(
   const key = `${currencyCode}:${compact}:${normalizedPrecision ?? 'default'}`;
   let fmt = currencyFormatCache.get(key);
   if (!fmt) {
-    const defaultDigits = compact ? 1 : 0;
-    const digits = normalizedPrecision ?? defaultDigits;
+    // Compact notation keeps up to 1 fraction digit (e.g. $40.5K) but must not force a
+    // trailing zero onto whole values (e.g. $40, not $40.0); standard notation defaults
+    // to whole currency amounts. An explicit precision pins both bounds.
+    const minimumFractionDigits = normalizedPrecision ?? 0;
+    const maximumFractionDigits = normalizedPrecision ?? (compact ? 1 : 0);
     // react-doctor-disable-next-line react-doctor/js-hoist-intl -- cached; only created once per currency+compact combination
     fmt = new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency: currencyCode,
       currencyDisplay: 'narrowSymbol',
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
+      minimumFractionDigits,
+      maximumFractionDigits,
       notation: compact ? 'compact' : 'standard',
       compactDisplay: 'short',
     });

--- a/packages/x-studio/src/internals/queryDescriptor.test.ts
+++ b/packages/x-studio/src/internals/queryDescriptor.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildQueryDescriptor, filtersToFilterNode } from './queryDescriptor';
+import { getCachedEnrichedRows } from './enrichedRowsCache';
+import { computeAggregate } from '../components/widgets/StudioKpiWidget/kpiUtils';
 import type { StudioFilterState, StudioWidget, StudioWidgetConfig } from '../models';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -135,6 +137,75 @@ describe('buildQueryDescriptor', () => {
         expect.objectContaining({ field: 'revenue', fn: 'avg', alias: 'revenue' }),
       ]),
     );
+  });
+
+  // ── Expression (calculated) field expansion (BL-201) ─────────────────────────
+  // The server can only project/aggregate physical columns. A KPI whose value field is an
+  // expression (e.g. `price - cost`) must NOT push the expression to the server; instead the
+  // native dependencies are selected and the expression is re-derived client-side.
+
+  const marginExprField = {
+    id: 'expr-margin',
+    label: 'Margin',
+    sourceId: 'source-orders',
+    isMeasure: false,
+    type: 'number' as const,
+    expression: { operator: 'subtract' as const, inputs: [{ id: 'price' }, { id: 'cost' }] },
+  };
+
+  it('expands an expression KPI value field to its native dependencies in select', () => {
+    const widget = makeWidget({ kpiValueField: 'expr-margin', kpiAggregation: 'avg' });
+    const desc = buildQueryDescriptor(widget, [], PAGE_ID, undefined, [marginExprField]);
+    expect(desc.select).toEqual(expect.arrayContaining(['price', 'cost']));
+    expect(desc.select).not.toContain('expr-margin');
+  });
+
+  it('drops expression-field aggregations (cannot be computed server-side)', () => {
+    const widget = makeWidget({ kpiValueField: 'expr-margin', kpiAggregation: 'avg' });
+    const desc = buildQueryDescriptor(widget, [], PAGE_ID, undefined, [marginExprField]);
+    expect(desc.aggregations?.some((a) => a.field === 'expr-margin')).not.toBe(true);
+  });
+
+  it('leaves native value fields untouched when expression fields are supplied', () => {
+    const widget = makeWidget({ kpiValueField: 'revenue', kpiAggregation: 'sum' });
+    const desc = buildQueryDescriptor(widget, [], PAGE_ID, undefined, [marginExprField]);
+    expect(desc.select).toContain('revenue');
+    expect(desc.aggregations).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: 'revenue', fn: 'sum' })]),
+    );
+  });
+
+  it('end-to-end: a server returning the native columns yields a non-zero expression KPI (BL-201)', () => {
+    // Reproduces the adapter/server path: the descriptor selects native deps (no expression
+    // column), a "server" projects those raw columns, then the client enriches + aggregates.
+    const widget = makeWidget({ kpiValueField: 'expr-margin', kpiAggregation: 'avg' });
+    const desc = buildQueryDescriptor(widget, [], PAGE_ID, undefined, [marginExprField]);
+
+    // Simulated server: returns only the requested physical columns (no expr-margin).
+    const dbRows = [
+      { price: 1299, cost: 850 },
+      { price: 49, cost: 18 },
+    ];
+    const serverRows = dbRows.map((r) => {
+      const projected: Record<string, unknown> = {};
+      for (const col of desc.select) {
+        projected[col] = r[col as 'price' | 'cost'];
+      }
+      return projected;
+    });
+
+    // Client re-derives the expression column from the native inputs.
+    const enriched = getCachedEnrichedRows(
+      serverRows,
+      'source-orders',
+      [marginExprField as never],
+      { 'source-orders': { id: 'source-orders', label: 'Orders', fields: [], rows: serverRows } },
+      [],
+      new Set(['expr-margin']),
+    );
+    const value = computeAggregate(enriched, 'expr-margin', 'avg');
+    expect(value).toBeGreaterThan(0); // (449 + 31) / 2 = 240
+    expect(value).toBe(240);
   });
 
   it('includes page-scoped filters in the descriptor', () => {

--- a/packages/x-studio/src/internals/queryDescriptor.ts
+++ b/packages/x-studio/src/internals/queryDescriptor.ts
@@ -1,10 +1,13 @@
 import type {
+  StudioExpression,
+  StudioExpressionField,
   StudioFilterNode,
   StudioFilterState,
   StudioQueryDescriptor,
   StudioWidget,
 } from '../models';
 import { resolveDateRangePresets } from './filterUtils';
+import { isFieldExpression, isFunctionExpression } from '../utils/expressionEvaluator';
 
 function sortedStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') {
@@ -177,12 +180,83 @@ export function collectSelectFields(widget: StudioWidget): string[] {
   return [...fields].filter(Boolean);
 }
 
+// ── Expression-field expansion ──────────────────────────────────────────────
+//
+// Servers and adapters can only project and aggregate *physical* columns. An
+// expression field (e.g. `price - cost`, or `stock * price`) is a client-side
+// concept: the database has no such column, so it cannot be SELECTed and it
+// certainly cannot be aggregated server-side (e.g. `avg(price - cost)` is not the
+// same as a column average). These helpers replace expression fields with the
+// native columns they depend on so the rows come back with the raw inputs, and
+// the expression is re-derived client-side after the fetch (see useWidgetRows).
+
+function collectExpressionRefs(expr: StudioExpression): string[] {
+  const refs: string[] = [];
+  const walk = (node: StudioExpression): void => {
+    if (isFieldExpression(node)) {
+      refs.push(node.id);
+    } else if (isFunctionExpression(node)) {
+      node.inputs.forEach(walk);
+    }
+    // JoinFieldExpression / ValueExpression reference no native column on this source.
+  };
+  walk(expr);
+  return refs;
+}
+
+/**
+ * Replaces any expression-field IDs in `fields` with the native field IDs they
+ * (transitively) depend on. Native fields and unknown IDs pass through unchanged.
+ */
+export function expandToNativeFields(
+  fields: string[],
+  expressionFields: StudioExpressionField[],
+  sourceId: string | undefined,
+): string[] {
+  if (!sourceId || expressionFields.length === 0) {
+    return fields;
+  }
+  const exprById = new Map(
+    expressionFields.filter((ef) => ef.sourceId === sourceId).map((ef) => [ef.id, ef]),
+  );
+  if (exprById.size === 0) {
+    return fields;
+  }
+  const result = new Set<string>();
+  const expanding = new Set<string>();
+  const addNative = (id: string): void => {
+    const expr = exprById.get(id);
+    if (!expr) {
+      result.add(id); // physical column (or unknown — leave for the server to validate)
+      return;
+    }
+    if (expanding.has(id)) {
+      return; // guard against cyclic expression definitions
+    }
+    expanding.add(id);
+    for (const ref of collectExpressionRefs(expr.expression)) {
+      addNative(ref);
+    }
+  };
+  fields.forEach(addNative);
+  return [...result];
+}
+
+function isExpressionField(
+  fieldId: string,
+  expressionFields: StudioExpressionField[],
+  sourceId: string | undefined,
+): boolean {
+  return expressionFields.some((ef) => ef.id === fieldId && ef.sourceId === sourceId);
+}
+
 // ── Aggregations builder ────────────────────────────────────────────────────
 
 type AggFn = 'sum' | 'avg' | 'count' | 'min' | 'max' | 'count_distinct';
 
 function buildAggregations(
   widget: StudioWidget,
+  expressionFields: StudioExpressionField[] = [],
 ): { field: string; fn: AggFn; alias: string }[] | undefined {
   const { config } = widget;
   const aggs: { field: string; fn: AggFn; alias: string }[] = [];
@@ -191,8 +265,14 @@ function buildAggregations(
     return undefined;
   }
 
+  // Expression-field aggregations cannot be pushed to the server (no physical column,
+  // and a computed-column aggregate is not a column aggregate). They are dropped here
+  // and recomputed client-side from the enriched raw rows.
+  const isExpr = (fieldId: string): boolean =>
+    isExpressionField(fieldId, expressionFields, widget.sourceId);
+
   // Single Y field — skip scatter (raw rows, no aggregation) and gantt (no yField anyway)
-  if (config.yField && config.chartType !== 'scatter') {
+  if (config.yField && config.chartType !== 'scatter' && !isExpr(config.yField)) {
     const fn = (config.yAggregation as AggFn | undefined) ?? 'sum';
     aggs.push({ field: config.yField, fn, alias: config.yField });
   }
@@ -201,7 +281,7 @@ function buildAggregations(
   // series are queried separately against their own source, so they are excluded here.
   if (config.ySeries) {
     config.ySeries.forEach((s) => {
-      if (!s.fieldId || (s.sourceId && s.sourceId !== widget.sourceId)) {
+      if (!s.fieldId || (s.sourceId && s.sourceId !== widget.sourceId) || isExpr(s.fieldId)) {
         return;
       }
       const fn = (s.yAggregation as AggFn | undefined) ?? 'sum';
@@ -210,7 +290,7 @@ function buildAggregations(
   }
 
   // KPI
-  if (config.kpiValueField) {
+  if (config.kpiValueField && !isExpr(config.kpiValueField)) {
     const fn = (config.kpiAggregation as AggFn | undefined) ?? 'sum';
     aggs.push({ field: config.kpiValueField, fn, alias: config.kpiValueField });
   }
@@ -223,25 +303,27 @@ function buildAggregations(
         const fn =
           (col.aggregationFn as AggFn | undefined) ??
           (config.gridAggregations?.[col.fieldId] as AggFn | undefined);
-        if (fn && col.fieldId !== config.gridGroupByField) {
+        if (fn && col.fieldId !== config.gridGroupByField && !isExpr(col.fieldId)) {
           aggs.push({ field: col.fieldId, fn, alias: col.fieldId });
         }
       });
     } else if (config.gridAggregations) {
       Object.entries(config.gridAggregations).forEach(([field, fn]) => {
-        aggs.push({ field, fn: fn as AggFn, alias: field });
+        if (!isExpr(field)) {
+          aggs.push({ field, fn: fn as AggFn, alias: field });
+        }
       });
     }
   }
 
   // Map / choropleth — aggregate the value field per country for db-tier push-down
-  if (widget.kind === 'map' && config.mapValueField) {
+  if (widget.kind === 'map' && config.mapValueField && !isExpr(config.mapValueField)) {
     const fn = (config.mapAggregation as AggFn | undefined) ?? 'sum';
     aggs.push({ field: config.mapValueField, fn, alias: config.mapValueField });
   }
 
   // Pivot table — aggregate the value field per (row, col) for db-tier push-down
-  if (widget.kind === 'pivot' && config.pivotValueField) {
+  if (widget.kind === 'pivot' && config.pivotValueField && !isExpr(config.pivotValueField)) {
     const fn = (config.pivotAggregation as AggFn | undefined) ?? 'sum';
     aggs.push({ field: config.pivotValueField, fn, alias: config.pivotValueField });
   }
@@ -262,12 +344,16 @@ function buildAggregations(
  * @param activePageId - The currently active page ID (from dashboard state).
  * @param tableName - Optional database table name. When provided, takes precedence
  *   over the source ID for server-side batch queries.
+ * @param expressionFields - Expression (calculated) fields for the widget's source.
+ *   Used to expand expression columns to their native dependencies in `select` and to
+ *   exclude expression-field aggregations (both are computed client-side instead).
  */
 export function buildQueryDescriptor(
   widget: StudioWidget,
   filters: StudioFilterState[],
   activePageId: string,
   tableName?: string,
+  expressionFields: StudioExpressionField[] = [],
 ): StudioQueryDescriptor {
   const pageFilters = filters.filter((f) => f.scope === 'page');
   const widgetFilters = filters.filter(
@@ -289,10 +375,16 @@ export function buildQueryDescriptor(
   ]);
   const filter = filtersToFilterNode(allFilters);
 
-  const select = collectSelectFields(widget);
+  // Expression columns are expanded to the native columns they depend on — the server
+  // returns the raw inputs and the expression is re-derived client-side.
+  const select = expandToNativeFields(
+    collectSelectFields(widget),
+    expressionFields,
+    widget.sourceId,
+  );
   const groupBy = widget.config?.xField ?? widget.config?.gridGroupByField;
   const xGroupBy = widget.config?.xGroupBy;
-  const aggregations = buildAggregations(widget);
+  const aggregations = buildAggregations(widget, expressionFields);
 
   // Compute a stable cache key from query shape (no widgetId) so widgets with
   // identical queries — same source, filters, select, groupBy, aggregations —

--- a/packages/x-studio/src/internals/useWidgetRows.ts
+++ b/packages/x-studio/src/internals/useWidgetRows.ts
@@ -14,6 +14,7 @@ import {
 } from '../context';
 import { resolveRowsCached } from './resolvedRowsCache';
 import { buildQueryDescriptor, collectSelectFields } from './queryDescriptor';
+import { getCachedEnrichedRows } from './enrichedRowsCache';
 import { getCachedNormalizedDataSource } from './normalizedRowsCache';
 import { studioRequestCache } from './StudioRequestCache';
 import { enrichWithCrossSourceFields } from './crossSourceEnrichment';
@@ -150,8 +151,14 @@ export function useWidgetRows(
     if (!hasAdapter || !widget.sourceId) {
       return null;
     }
-    return buildQueryDescriptor(widget, filters, activePageId, dataSource?.tableName);
-  }, [hasAdapter, widget, filters, activePageId, dataSource]);
+    return buildQueryDescriptor(
+      widget,
+      filters,
+      activePageId,
+      dataSource?.tableName,
+      expressionFields,
+    );
+  }, [hasAdapter, widget, filters, activePageId, dataSource, expressionFields]);
 
   // Async state: rows fetched from adapter.
   const [adapterRows, setAdapterRows] = React.useState<Row[]>(() => {
@@ -279,9 +286,36 @@ export function useWidgetRows(
   // 2. There is a chart-click cross-filter active (never for interactive/filter-widget filters)
   const shouldShowGhost = crossFilterMode === 'cross-highlight' && hasChartCrossFilters;
 
+  // Adapter/server responses contain only physical columns — expression (calculated)
+  // fields are a client-side concept the server cannot produce. Enrich the returned raw
+  // rows with expression columns here so KPIs/charts using a calculated value field (e.g.
+  // `price - cost`) aggregate against real values instead of `undefined` (which renders $0).
+  // No-op for aggregated responses where the requested fields are already physical.
+  const enrichedAdapterRows = React.useMemo((): Row[] => {
+    if (!hasAdapter || !widget.sourceId || adapterRows.length === 0) {
+      return adapterRows;
+    }
+    return getCachedEnrichedRows(
+      adapterRows,
+      widget.sourceId,
+      expressionFields,
+      dataSources,
+      relationships,
+      usedFieldIds,
+    );
+  }, [
+    hasAdapter,
+    adapterRows,
+    widget.sourceId,
+    expressionFields,
+    dataSources,
+    relationships,
+    usedFieldIds,
+  ]);
+
   const filteredRows = React.useMemo((): Row[] => {
     if (hasAdapter) {
-      return adapterRows;
+      return enrichedAdapterRows;
     }
     if (!normalizedDataSource?.rows) {
       return [];
@@ -308,7 +342,7 @@ export function useWidgetRows(
     );
   }, [
     hasAdapter,
-    adapterRows,
+    enrichedAdapterRows,
     normalizedDataSource,
     deferredPartitioned,
     dataSources,

--- a/packages/x-studio/src/models/baseTypes.ts
+++ b/packages/x-studio/src/models/baseTypes.ts
@@ -170,6 +170,20 @@ export interface StudioFeatureFlags {
    * @default true
    */
   aiChat?: boolean;
+  /**
+   * Enable the per-widget AI insight features (the "AI insight" button and chart anomaly
+   * detection/explanation). Requires `aiConfig` to also be provided — this flag only controls
+   * visibility. Set to `false` to keep the AI chat assistant while hiding per-widget AI actions.
+   * @default true
+   */
+  aiInsights?: boolean;
+  /**
+   * Allow exporting widget data from the card action menu — CSV for table/pivot widgets and
+   * PNG for charts. Set to `false` to remove the export button in both edit and view modes
+   * (useful when the underlying data must not leave the dashboard).
+   * @default true
+   */
+  export?: boolean;
 
   // ── Widget kind availability ───────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes BL-201 through BL-205 from `packages/x-studio/BACKLOG.md`. Branched from `x-studio`.

## BL-201 — Products-page KPIs showing $0
The agent's first theory (flip `isMeasure`) was wrong — the in-memory pipeline computes both KPIs correctly (margin avg = 243.51, inventory sum = 1.39M, reproduced against the real config). The actual cause is the **adapter/server data path**: "Avg Unit Margin" and "Total Inventory Value" use expression value fields (`price - cost`, `stock * price`), which the server cannot project or aggregate (the column allowlist even rejects `expr-product-margin`), and `useWidgetRows` never enriched adapter-returned rows. Native-field KPIs (Units Sold) worked; expression ones returned $0.

Fix:
- `buildQueryDescriptor` expands expression columns to their native dependencies in `select` and drops expression-field aggregations (a computed-column aggregate is not a column aggregate).
- `useWidgetRows` enriches adapter rows with expression columns client-side via `getCachedEnrichedRows`.
- New `expandToNativeFields` export + descriptor and end-to-end tests.

## BL-202 — Missing feature flags
Added two embedder-facing flags that previously had no toggle:
- `aiInsights` — per-widget AI insight button + chart anomaly detection/explanation (gated independently of `aiChat`).
- `export` — widget CSV/PNG export action.

Both resolve in `useStudioFeatures()` (default `true`), are gated in `StudioWidgetCard`, and exposed in the shared `FeatureFlagSettings` used by both example apps.

## BL-203 — `$40.0` instead of `$40`
Compact currency forced `minimumFractionDigits: 1`. `getCurrencyFormat` now decouples the bounds (min 0, max 1 for compact) so whole values stay `$40` while `$40.5K` keeps its digit; an explicit precision still pins both bounds.

## BL-204 — Toggle-chips clear button
Moved the clear button from its own top row into the chips flex container as the last item, so it wraps inline with the chips and no longer grows the widget height.

## BL-205 — Conditional formatting location
Extracted the rule editor into a new `GridConditionalFormatSection` and render it from `FormatPanel` (Format tab) instead of `GridSetupPanel` (Setup tab); removed the now-unused presets/operators/imports from `GridSetupPanel`. The `gridConditionalFormats` feature flag is still respected.

## Verification
- TypeScript clean: x-studio package + `x-studio` and `x-studio-composed` example apps.
- ESLint + Prettier clean on all changed source.
- Full x-studio suite: 1249 passed, plus the new tests.

## Note — pre-existing failure (not from this PR)
`StudioPivotWidget.test.tsx` expects a standalone CSV button, but pivot export was moved to the card header (`exportRef`) in an earlier x-studio commit. Confirmed it fails on the branch **without** these changes, so it was left untouched to avoid scope creep — happy to fix the test separately if wanted.

https://claude.ai/code/session_018erqyHnZVsKkK9Aoosj8mc

---
_Generated by [Claude Code](https://claude.ai/code/session_018erqyHnZVsKkK9Aoosj8mc)_