### PR TITLE
feat(x-studio): wire dashboard state through dev server and MCP

### DIFF
--- a/examples/x-studio-ai/src/AppLayout.tsx
+++ b/examples/x-studio-ai/src/AppLayout.tsx
@@ -89,7 +89,20 @@ export function AppLayout({
     }
 
     onSaveController(activeChatId);
-    downloadJson(controller.serializeState(), `dashboard-${activeChatId}.json`);
+    const serialized = controller.serializeState();
+    downloadJson(serialized, `dashboard-${activeChatId}.json`);
+    const serverUrl = import.meta.env.STUDIO_SERVER_URL as string | undefined;
+    if (serverUrl) {
+      const token = import.meta.env.STUDIO_SERVER_TOKEN as string | undefined;
+      fetch(`${serverUrl.replace(/\/$/, '')}/api/dashboard-state`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(serialized),
+      }).catch(() => {});
+    }
   }, [activeChatId, controller, onSaveController]);
 
   const handleLoad = React.useCallback(async () => {

--- a/examples/x-studio-composed/src/App.tsx
+++ b/examples/x-studio-composed/src/App.tsx
@@ -533,6 +533,28 @@ function DashboardLayout({
     // react-doctor-disable-next-line react-doctor/exhaustive-deps -- intentional mount-only effect
   }, []);
 
+  // Load saved dashboard state from the dev server on mount (overrides localStorage if available)
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- example app
+  React.useEffect(() => {
+    const serverUrl = import.meta.env.STUDIO_SERVER_URL as string | undefined;
+    if (!serverUrl) {
+      return;
+    }
+    const token = import.meta.env.STUDIO_SERVER_TOKEN as string | undefined;
+    fetch(`${serverUrl.replace(/\/$/, '')}/api/dashboard-state`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((state) => {
+        if (state) {
+          controller.loadSerializedState(state);
+        }
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- intentional mount-only effect
+  }, []);
+
   // Sync active page id to the URL ?page= query param
   const { activePageId } = dashboard;
   React.useEffect(() => {
@@ -600,6 +622,18 @@ function DashboardLayout({
       '_',
     );
     downloadJson(serialized, `${title}_dashboard.json`);
+    const serverUrl = import.meta.env.STUDIO_SERVER_URL as string | undefined;
+    if (serverUrl) {
+      const token = import.meta.env.STUDIO_SERVER_TOKEN as string | undefined;
+      fetch(`${serverUrl.replace(/\/$/, '')}/api/dashboard-state`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(serialized),
+      }).catch(() => {});
+    }
     onSnackbar(t.dashboardSavedMessage, 'success');
   }, [controller, onSnackbar, t]);
 

--- a/examples/x-studio-dev-server/src/app.ts
+++ b/examples/x-studio-dev-server/src/app.ts
@@ -9,6 +9,7 @@ import { makeCrmDataRouter } from './routes/crmData.js';
 import { makeAIRouter } from './routes/ai.js';
 import { makeDevTokenRouter } from './routes/devToken.js';
 import { makeMcpRouter } from './routes/mcp.js';
+import { makeDashboardStateRouter } from './routes/dashboardState.js';
 import { error } from './logger.js';
 
 export function buildApp(salesDb: Knex, crmDb: Knex, config: Config): express.Application {
@@ -47,6 +48,7 @@ export function buildApp(salesDb: Knex, crmDb: Knex, config: Config): express.Ap
   app.use('/api/ai', makeAIRouter(salesDb, crmDb, config));
   app.use('/api/dev-token', makeDevTokenRouter(config));
   app.use('/api/mcp', makeMcpRouter(salesDb, crmDb, config));
+  app.use('/api/dashboard-state', makeDashboardStateRouter());
 
   // Global error handler
   app.use(

--- a/examples/x-studio-dev-server/src/index.ts
+++ b/examples/x-studio-dev-server/src/index.ts
@@ -42,6 +42,7 @@ async function main(): Promise<void> {
     log(`[startup]   CRM API:   http://localhost:${config.port}/api/crm-data`);
     log(`[startup]   AI API:    http://localhost:${config.port}/api/ai/chat`);
     log(`[startup]   MCP API:   http://localhost:${config.port}/api/mcp`);
+    log(`[startup]   Dashboard: http://localhost:${config.port}/api/dashboard-state`);
     if (!config.studioToken) {
       log(`[startup]   Dev token: http://localhost:${config.port}/api/dev-token`);
       log('[startup]   ⚠ Running in open dev mode (no STUDIO_TOKEN set)');

--- a/examples/x-studio-dev-server/src/routes/dashboardState.ts
+++ b/examples/x-studio-dev-server/src/routes/dashboardState.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { log } from '../logger.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STATE_FILE = path.resolve(__dirname, '../../dashboard-state.json');
+
+let dashboardState: unknown | null = null;
+
+// Hydrate from disk on module load
+try {
+  dashboardState = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+  log('[dashboard-state] Loaded saved state from disk');
+} catch {
+  // First run — file doesn't exist yet
+}
+
+export function getDashboardState(): unknown | null {
+  return dashboardState;
+}
+
+export function setDashboardState(state: unknown): void {
+  dashboardState = state;
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+export function makeDashboardStateRouter(): Router {
+  const router = Router();
+
+  router.get('/', (_req, res) => {
+    if (!dashboardState) {
+      res.status(404).json({ error: 'No saved dashboard state' });
+      return;
+    }
+    res.json(dashboardState);
+  });
+
+  router.post('/', (req, res) => {
+    setDashboardState(req.body);
+    log('[dashboard-state] State saved');
+    res.json({ success: true });
+  });
+
+  return router;
+}

--- a/examples/x-studio-dev-server/src/routes/mcp.ts
+++ b/examples/x-studio-dev-server/src/routes/mcp.ts
@@ -49,7 +49,10 @@ import {
   type StudioStateBox,
   type StudioDataQueryParams,
 } from '@mui/x-studio-ai-middleware';
+import type { StudioState } from '@mui/x-studio-ai-middleware';
+import type { SerializedStudioState } from '@mui/x-studio';
 import { log, error as logError } from '../logger.js';
+import { getDashboardState, setDashboardState } from './dashboardState.js';
 import {
   generateSalesData,
   generateCrmData,
@@ -207,8 +210,17 @@ export function makeMcpRouter(salesDb: Knex, crmDb: Knex, config: Config): Route
         claims = DEV_CLAIMS;
       }
 
+      const saved = getDashboardState() as SerializedStudioState | null;
       const stateBox: StudioStateBox = {
-        current: createDefaultStudioState(MCP_INITIAL_STATE),
+        current: createDefaultStudioState(
+          saved
+            ? ({
+                ...saved,
+                dataSources: MCP_INITIAL_DATA_SOURCES,
+                mode: 'edit',
+              } as Partial<StudioState>)
+            : MCP_INITIAL_STATE,
+        ),
       };
 
       const transport = new StreamableHTTPServerTransport({
@@ -216,15 +228,21 @@ export function makeMcpRouter(salesDb: Knex, crmDb: Knex, config: Config): Route
         onsessioninitialized: (sid) => {
           transports[sid] = transport;
           stateBoxes[sid] = stateBox;
-          log(`[mcp] session ${sid.slice(0, 8)}… initialized`);
+          log(`[mcp] session ${sid.slice(0, 8)}… initialized${saved ? ' (from saved state)' : ''}`);
         },
       });
 
-      // Clean up session on disconnect.
+      // Clean up session on disconnect, persisting any mutations made during the session.
       transport.onclose = () => {
         const sid = transport.sessionId;
         if (sid) {
           log(`[mcp] session ${sid.slice(0, 8)}… closed`);
+          const box = stateBoxes[sid];
+          if (box) {
+            const { dataSources: _ds, mode: _m, shell: _sh, ...persisted } = box.current;
+            setDashboardState(persisted);
+            log(`[mcp] session ${sid.slice(0, 8)}… state persisted`);
+          }
           delete transports[sid];
           delete stateBoxes[sid];
         }

--- a/examples/x-studio/src/App.tsx
+++ b/examples/x-studio/src/App.tsx
@@ -773,6 +773,28 @@ export default function App() {
     studioRef.current?.setActivePage(pageId);
   }, []);
 
+  // Load saved state from the dev server on mount, if STUDIO_SERVER_URL is configured.
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- example app: fetch without a data-fetching library is acceptable here
+  React.useEffect(() => {
+    const serverUrl = import.meta.env.STUDIO_SERVER_URL as string | undefined;
+    if (!serverUrl) {
+      return;
+    }
+    const token = import.meta.env.STUDIO_SERVER_TOKEN as string | undefined;
+    fetch(`${serverUrl.replace(/\/$/, '')}/api/dashboard-state`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((state) => {
+        if (state) {
+          studioRef.current?.loadSerializedState(state);
+        }
+      })
+      .catch(() => {
+        // Server offline — keep local state
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleSave = React.useCallback(() => {
     const serialized = studioRef.current?.serializeState();
     if (!serialized) {
@@ -783,6 +805,20 @@ export default function App() {
       '_',
     );
     downloadJson(serialized, `${dashboardTitle}_dashboard.json`);
+
+    const serverUrl = import.meta.env.STUDIO_SERVER_URL as string | undefined;
+    if (serverUrl) {
+      const token = import.meta.env.STUDIO_SERVER_TOKEN as string | undefined;
+      fetch(`${serverUrl.replace(/\/$/, '')}/api/dashboard-state`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(serialized),
+      }).catch(() => {});
+    }
+
     setSnackbar({ open: true, message: t.dashboardSavedMessage, severity: 'success' });
   }, [t]);
 


### PR DESCRIPTION
## Summary

- Adds `GET/POST /api/dashboard-state` endpoint to the dev server, backed by an in-memory store and `dashboard-state.json` on disk
- All three example apps (`x-studio`, `x-studio-composed`, `x-studio-ai`) load from the server on mount and POST the serialized state on save
- MCP server seeds each new session from saved state instead of the hard-coded `INITIAL_STATE`, and persists the final session state back to disk on session close

## Files changed

- **new** `examples/x-studio-dev-server/src/routes/dashboardState.ts` — shared state module (`getDashboardState`, `setDashboardState`, `makeDashboardStateRouter`)
- `examples/x-studio-dev-server/src/app.ts` — registers `/api/dashboard-state`
- `examples/x-studio-dev-server/src/index.ts` — logs the new endpoint at startup
- `examples/x-studio-dev-server/src/routes/mcp.ts` — seeds from saved state; persists on session close
- `examples/x-studio/src/App.tsx` — load on mount + POST on save
- `examples/x-studio-composed/src/App.tsx` — load on mount + POST on save
- `examples/x-studio-ai/src/AppLayout.tsx` — POST on save (no load-on-mount; each chat starts fresh)

## Test plan

- `cd examples/x-studio-dev-server && pnpm dev` — new log line shows `/api/dashboard-state`
- `curl http://localhost:3020/api/dashboard-state` → `404 No saved dashboard state`
- Run `x-studio` with `STUDIO_SERVER_URL=http://localhost:3020`, rearrange widgets, click **Save** → `200 { success: true }`
- Refresh page → layout restored from server
- Repeat for `x-studio-composed`
- In `x-studio-ai`, add widgets, click **Save** → state POSTed to server
- Open MCP client pointing at `http://localhost:3020/api/mcp` → `studio://dashboard/state` shows the saved layout, not generic `INITIAL_STATE`

---
_Generated by [Claude Code](https://claude.ai/code/session_016wjeqXqF4FTSrxgf4iUZtU)_